### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To get started using this boilerplate you only need to follow a few steps. First
 you should run `yarn` on your favorite terminal to initialize Yarn and install all the required
 dependencies.
 
-If you want to start developing your project you should run `yarn start`, this will generate
+If you want to start developing your project you should run `yarn run develop`, this will generate
 a development build (without optimizing the code for easy debug and all that stuff) based on a webpack dev-server
 with hot-reload and all those cool development features that we, programmers, love.
 


### PR DESCRIPTION
```
$ yarn start
yarn start v0.22.0
error Command "start" not found.
```

yarn run develop let me start the app.  Not sure if this is a change in yarn versions or what.

